### PR TITLE
feat(backend): parse commitment percentages

### DIFF
--- a/backend/src/services/investor_service.py
+++ b/backend/src/services/investor_service.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING, Union
 
 from sqlalchemy.orm import Session
 
@@ -65,7 +65,7 @@ class InvestorService:
         self,
         investor: Investor,
         fund: "Fund",
-        commitment_percentage: Decimal | float | int,
+        commitment_percentage: Union[Decimal, float, int],
     ) -> InvestorFundCommitment:
         """Create or update investor commitment percentage for a fund."""
         existing = (

--- a/backend/tests/test_excel_commitment_integration.py
+++ b/backend/tests/test_excel_commitment_integration.py
@@ -1,0 +1,68 @@
+"""Integration test covering Excel parsing through commitment persistence."""
+
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+
+from src.models.investor_fund_commitment import InvestorFundCommitment
+from src.services.excel_service import ExcelService
+from src.services.fund_service import FundService
+from src.services.investor_service import InvestorService
+
+
+def _dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "Investor Name": "Beta Holdings",
+                "Investor Entity Type": "Corporation",
+                "Investor Tax State": "CO",
+                "Commitment Percentage": "25.75%",
+                "Distribution CO": 1500,
+            }
+        ]
+    )
+
+
+def test_excel_flow_creates_investor_commitment(db_session, tmp_path, monkeypatch):
+    fake_file = tmp_path / "commitment_input.xlsx"
+    fake_file.write_bytes(b"ignored")
+
+    monkeypatch.setattr(pd, "read_excel", lambda *args, **kwargs: _dataframe())
+
+    service = ExcelService()
+
+    result = service.parse_excel_file(
+        fake_file,
+        "(Input Data) FundBeta_Q2 2024 distribution data_v1.3.xlsx",
+    )
+
+    assert result.errors == []
+    assert result.valid_rows == 1
+
+    fund_service = FundService(db_session)
+    investor_service = InvestorService(db_session)
+
+    fund = fund_service.get_or_create_fund(
+        result.fund_info["fund_code"],
+        result.fund_info["period_quarter"],
+        int(result.fund_info["period_year"]),
+    )
+
+    for row in result.data:
+        investor = investor_service.find_or_create_investor(
+            row["investor_name"],
+            row["investor_entity_type"],
+            row["investor_tax_state"],
+        )
+        investor_service.upsert_commitment(
+            investor=investor,
+            fund=fund,
+            commitment_percentage=row["commitment_percentage"],
+        )
+
+    stored = db_session.query(InvestorFundCommitment).all()
+    assert len(stored) == 1
+    assert stored[0].commitment_percentage == Decimal("25.7500")
+    assert stored[0].fund_code == result.fund_info["fund_code"]

--- a/backend/tests/unit/test_excel_service_commitment.py
+++ b/backend/tests/unit/test_excel_service_commitment.py
@@ -1,0 +1,95 @@
+"""Unit coverage for commitment percentage parsing in ExcelService."""
+
+from decimal import Decimal
+from pathlib import Path
+from typing import Callable, Dict, Optional, Tuple
+
+import pandas as pd
+import pytest
+
+from src.services.excel_service import ExcelService
+
+
+def _make_dataframe(overrides: Optional[Dict[str, object]] = None) -> pd.DataFrame:
+    base_row = {
+        "Investor Name": "Alpha Capital",
+        "Investor Entity Type": "Corporation",
+        "Investor Tax State": "TX",
+        "Commitment Percentage": "12.5%",
+        "Distribution TX": 1000,
+    }
+    if overrides:
+        base_row.update(overrides)
+    return pd.DataFrame([base_row])
+
+
+def _run_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dataframe_factory: Callable[[], pd.DataFrame],
+) -> Tuple[ExcelService, pd.DataFrame]:
+    fake_file = tmp_path / "input.xlsx"
+    fake_file.write_bytes(b"ignored by mock")
+
+    df = dataframe_factory()
+    monkeypatch.setattr(pd, "read_excel", lambda *args, **kwargs: df)
+
+    service = ExcelService()
+    result = service.parse_excel_file(
+        fake_file,
+        "(Input Data) FundAlpha_Q1 2024 distribution data_v1.3.xlsx",
+    )
+    return service, result
+
+
+def test_commitment_percentage_parses_and_quantizes(tmp_path, monkeypatch):
+    _, result = _run_parse(tmp_path, monkeypatch, lambda: _make_dataframe())
+
+    assert result.valid_rows == 1
+    assert result.errors == []
+    assert result.data[0]["commitment_percentage"] == Decimal("12.5000")
+
+
+def test_missing_commitment_percentage_is_error(tmp_path, monkeypatch):
+    _, result = _run_parse(
+        tmp_path,
+        monkeypatch,
+        lambda: _make_dataframe({"Commitment Percentage": ""}),
+    )
+
+    assert result.valid_rows == 0
+    assert any(
+        error.error_code == "EMPTY_FIELD"
+        and error.column_name == "Commitment Percentage"
+        for error in result.errors
+    )
+
+
+def test_duplicate_investor_rows_raise_error(tmp_path, monkeypatch):
+    def dataframe():
+        return pd.concat(
+            [
+                _make_dataframe(),
+                _make_dataframe({"Commitment Percentage": "15%"}),
+            ],
+            ignore_index=True,
+        )
+
+    _, result = _run_parse(tmp_path, monkeypatch, dataframe)
+
+    assert result.valid_rows == 1
+    assert any(error.error_code == "DUPLICATE_INVESTOR" for error in result.errors)
+
+
+def test_commitment_percentage_out_of_range(tmp_path, monkeypatch):
+    _, result = _run_parse(
+        tmp_path,
+        monkeypatch,
+        lambda: _make_dataframe({"Commitment Percentage": "120"}),
+    )
+
+    assert result.valid_rows == 0
+    assert any(
+        error.error_code == "PERCENTAGE_OUT_OF_RANGE"
+        for error in result.errors
+    )

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -59,6 +59,7 @@ export interface ResultsPreviewRow {
   withholding_exemption?: string;
   composite_tax_amount?: number | null;
   withholding_tax_amount?: number | null;
+  commitment_percentage?: number | null;
 }
 
 export interface ResultsPreviewResponse {


### PR DESCRIPTION
## Summary
- enforce required commitment percentage parsing with validation and duplicate checks
- persist investor commitments during upload and normalize values for FundFlow v1.3
- add backend unit/integration tests to cover commitment parsing and persistence

## Testing
- pytest backend/tests/unit/test_excel_service_commitment.py
- pytest backend/tests/test_excel_commitment_integration.py
- make lint *(fails: ImportError: cannot import name '_unicodefun' from 'click')*
- npm run build *(fails: tsc: command not found)*

cc @coderabbitai